### PR TITLE
perf: 缓存分层、选股流式体验与图表/预取交互优化

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 ## 目录
 
+- [快速开始](#快速开始)
 - [界面预览](#界面预览)
 - [项目概览](#项目概览)
 - [系统架构](#系统架构)
@@ -18,6 +19,77 @@
 - [配置与参数](#配置与参数)
 - [常见问题](#常见问题)
 - [免责声明](#免责声明)
+
+---
+
+## 快速开始
+
+本地跑通只需 **Python 3.10+**、**Node.js 18+** 与 **npm**（也可用 pnpm）。行情与缠论分析不配置 AI Key 也能用；AI 诊股与 LLM 策略需在后端 `.env` 中填写 Key。
+
+### 1. 克隆仓库
+
+```bash
+git clone https://github.com/TensorCode666/stock-chanlun.git
+cd stock-chanlun
+```
+
+### 2. 安装并启动后端
+
+```bash
+cd backend
+
+# 创建并激活虚拟环境（推荐）
+python -m venv .venv
+
+# Windows
+.venv\Scripts\activate
+
+# macOS / Linux
+# source .venv/bin/activate
+
+pip install -r requirements.txt
+
+# 可选：复制本地数据模板（自选 / 笔记 / AI 设置）
+# Windows:
+#   copy settings.json.example settings.json
+#   copy watchlist.json.example watchlist.json
+#   copy comments.json.example comments.json
+# macOS / Linux:
+#   cp settings.json.example settings.json
+#   cp watchlist.json.example watchlist.json
+#   cp comments.json.example comments.json
+
+# 可选：AI 能力 — 复制 backend/.env.example 为 .env 并填入 DEEPSEEK_API_KEY 或 GEMINI_API_KEY
+
+python run_server.py
+```
+
+后端默认监听 **http://127.0.0.1:8010**（与前端开发代理一致）。启动后可在浏览器打开 [http://127.0.0.1:8010/docs](http://127.0.0.1:8010/docs) 查看 API，或执行：
+
+```bash
+curl http://127.0.0.1:8010/health
+```
+
+### 3. 安装并启动前端
+
+**新开一个终端**，在项目根目录执行：
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+终端会输出实际端口（默认 **5173**）。在浏览器访问（注意路径带 `base`）：
+
+| 端 | 地址 |
+|----|------|
+| PC 首页 | http://localhost:5173/stock-chanlun/ |
+| 移动端 | http://localhost:5173/stock-chanlun/m/ |
+
+> 若后端不用 8010 端口，请在启动前端前设置环境变量，例如：`set VITE_API_PROXY_TARGET=http://127.0.0.1:8000`（Windows）或 `export VITE_API_PROXY_TARGET=http://127.0.0.1:8000`（macOS/Linux），再执行 `npm run dev`。
+
+更完整的配置说明、生产构建与测试见下方 [安装部署](#安装部署)。
 
 ---
 
@@ -404,16 +476,21 @@ stock-chanlun/
 
 ## 安装部署
 
-### 前置条件
+上文 [快速开始](#快速开始) 已覆盖最常用的本地安装流程；本节补充环境要求、可选配置与生产部署细节。
 
-- Python 3.10+
-- Node.js 18+
-- npm 或 pnpm
+### 环境要求
+
+| 组件 | 版本 | 说明 |
+|------|------|------|
+| Python | 3.10+ | 后端与缠论计算 |
+| Node.js | 18+ | 前端构建与开发服务器 |
+| 包管理器 | npm / pnpm | 前端依赖安装 |
+| 操作系统 | Windows / macOS / Linux | 均可；下文命令分别标注 |
 
 ### 1. 克隆项目
 
 ```bash
-git clone <repo-url>
+git clone https://github.com/TensorCode666/stock-chanlun.git
 cd stock-chanlun
 ```
 
@@ -428,22 +505,35 @@ python -m venv .venv
 # Windows 激活
 .venv\Scripts\activate
 
-# macOS/Linux 激活
-source .venv/bin/activate
+# macOS / Linux 激活
+# source .venv/bin/activate
 
 # 安装依赖
 pip install -r requirements.txt
 ```
 
+**验证：** 激活虚拟环境后执行 `python -c "import fastapi, akshare; print('ok')"`，无报错即依赖就绪。
+
 ### 3. 配置环境变量与本地数据（可选）
 
 可参考 `backend/.env.example` 在 `backend/` 下创建 `.env`。首次运行前，将 JSON 模板复制为本地文件（勿提交 Git）：
+
+**macOS / Linux：**
 
 ```bash
 cd backend
 cp settings.json.example settings.json
 cp watchlist.json.example watchlist.json
 cp comments.json.example comments.json
+```
+
+**Windows（CMD / PowerShell）：**
+
+```bat
+cd backend
+copy settings.json.example settings.json
+copy watchlist.json.example watchlist.json
+copy comments.json.example comments.json
 ```
 
 `.env` 示例：
@@ -487,17 +577,30 @@ python run_server.py
 ```bash
 cd frontend
 npm install
+# 或使用 pnpm：pnpm install
 ```
+
+**验证：** `npm run typecheck` 通过表示 TypeScript 与 Vue 类型检查正常（需已安装依赖）。
 
 ### 6. 启动前端开发服务器
 
 ```bash
+cd frontend
 npm run dev
-# PC 首页： http://localhost:5173/stock-chanlun/
-# 移动端：  http://localhost:5173/stock-chanlun/m/
+```
 
+| 用途 | 地址 |
+|------|------|
+| PC 首页 | http://localhost:5173/stock-chanlun/ |
+| 移动端 | http://localhost:5173/stock-chanlun/m/ |
+| API 代理目标 | 默认 `http://127.0.0.1:8010`（见 `frontend/vite.config.ts`） |
+
+端口被占用时 Vite 会自动顺延（如 5174），以终端输出为准。
+
+```bash
 # 生成 README 截图时建议使用固定端口，避免与其他 Vite 实例冲突：
-# npm run dev:screenshots   # → http://localhost:5188/stock-chanlun/
+npm run dev:screenshots
+# → http://localhost:5188/stock-chanlun/
 ```
 
 ### 7. 生产构建

--- a/backend/services/akshare_service.py
+++ b/backend/services/akshare_service.py
@@ -1221,7 +1221,7 @@ def _fetch_em_hot_stocks(limit: int) -> list:
                     "invt": 2,
                     "fid": "f3",
                     "fs": "m:0+t:6,m:0+t:13,m:1+t:2,m:1+t:23",
-                    "fields": "f2,f3,f4,f12,f14",
+                    "fields": "f2,f3,f4,f5,f6,f12,f14",
                     "ut": "bd1d9ddb04089700cf9c27f6f7426281",
                 },
                 timeout=20.0,
@@ -1234,8 +1234,10 @@ def _fetch_em_hot_stocks(limit: int) -> list:
                 try:
                     price = float(row.get("f2", 0) or 0)
                     chg = float(row.get("f3", 0) or 0)
+                    volume = float(row.get("f5", 0) or 0)
+                    amount = float(row.get("f6", 0) or 0)
                 except (TypeError, ValueError):
-                    price, chg = 0.0, 0.0
+                    price, chg, volume, amount = 0.0, 0.0, 0.0, 0.0
                 code = str(row.get("f12", "") or "").strip()
                 name = str(row.get("f14", "") or "").strip()
                 if not code:
@@ -1245,7 +1247,8 @@ def _fetch_em_hot_stocks(limit: int) -> list:
                     "name": name,
                     "change_pct": round(chg, 2),
                     "price": round(price, 2),
-                    "volume": 0,
+                    "volume": volume,
+                    "amount": amount,
                 })
             return stocks
         except Exception as e:

--- a/backend/services/screening_service.py
+++ b/backend/services/screening_service.py
@@ -258,21 +258,10 @@ def screen_stocks_stream(
     need_industry_name = industry is not None
     need_pe_pb = pe_max is not None or pb_max is not None
     seed = _quotes_from_hot(hot_list)
+    quote_map = _quote_map_from_seed(candidates, seed)
 
-    # 热门池已含涨跌幅/成交量；仅行业或 PE/PB 需额外拉行情与基本面
-    if need_industry_name or need_pe_pb:
-        quote_map = _get_quote_and_info(
-            candidates,
-            need_industry_name=need_industry_name,
-            need_pe_pb=need_pe_pb,
-            quote_seed=seed,
-        )
-    else:
-        quote_map = _quote_map_from_seed(candidates, seed)
-    t2 = time.time()
-    log.info("选股行情和基本面完成 elapsed=%.1fs", t2 - t1)
-
-    prefiltered = []
+    # 先用热门池行情做涨跌幅/成交量预过滤，缩小行业/PE 拉取范围
+    prefiltered_basic = []
     for code in candidates:
         q = quote_map.get(code, {})
         pct = q.get("change_pct", 0)
@@ -285,7 +274,24 @@ def screen_stocks_stream(
             continue
         if volume_max is not None and vol > volume_max:
             continue
-        if industry is not None and q.get("industry") != industry:
+        prefiltered_basic.append(code)
+
+    if (need_industry_name or need_pe_pb) and prefiltered_basic:
+        extra = _get_quote_and_info(
+            prefiltered_basic,
+            need_industry_name=need_industry_name,
+            need_pe_pb=need_pe_pb,
+            quote_seed=seed,
+        )
+        for code in prefiltered_basic:
+            quote_map[code] = {**quote_map.get(code, {}), **extra.get(code, {})}
+    t2 = time.time()
+    log.info("选股行情和基本面完成 elapsed=%.1fs", t2 - t1)
+
+    prefiltered = []
+    for code in prefiltered_basic:
+        q = quote_map.get(code, {})
+        if industry is not None and industry not in (q.get("industry") or ""):
             continue
         if pe_max is not None and q.get("pe") is not None and q["pe"] > pe_max:
             continue

--- a/backend/services/screening_service.py
+++ b/backend/services/screening_service.py
@@ -139,42 +139,57 @@ def _get_quote_and_info(
     *,
     need_industry_name: bool = False,
     need_pe_pb: bool = False,
+    quote_seed: dict[str, dict] | None = None,
 ) -> dict[str, dict]:
     """
     批量获取实时行情 + 基本面信息。
 
     need_industry_name: 拉取行业（东方财富板块接口）
     need_pe_pb: 拉取市盈率/市净率（腾讯行情 info 字段）
+    quote_seed: 热门池等已有行情时跳过全量实时报价拉取
     """
     result = {}
 
-    normalized_codes = [_normalize_code(c) for c in codes]
+    if quote_seed is not None:
+        for code in codes:
+            nc = _normalize_code(code)
+            base = quote_seed.get(nc, {})
+            result[code] = {
+                "price": float(base.get("price") or 0),
+                "change_pct": float(base.get("change_pct") or 0),
+                "volume": float(base.get("volume") or 0),
+                "amount": float(base.get("amount") or 0),
+                "name": base.get("name") or code,
+                "industry": None,
+                "pe": None,
+                "pb": None,
+            }
+    else:
+        quotes_df = get_realtime_quote(codes)
+        quotes_records = quotes_df.to_dict("records") if not quotes_df.empty else []
 
-    quotes_df = get_realtime_quote(codes)
-    quotes_records = quotes_df.to_dict("records") if not quotes_df.empty else []
+        qmap = {}
+        for q in quotes_records:
+            code_key = _normalize_code(q.get("代码") or q.get("code") or "")
+            qmap[code_key] = q
 
-    qmap = {}
-    for q in quotes_records:
-        code_key = _normalize_code(q.get("代码") or q.get("code") or "")
-        qmap[code_key] = q
+        for code in codes:
+            norm_code = _normalize_code(code)
+            q = qmap.get(norm_code, {})
+            price = float(q.get("最新价") or q.get("price") or 0)
+            prev_close = float(q.get("昨收") or q.get("prev_close") or 0)
+            change_pct = ((price - prev_close) / prev_close * 100) if prev_close else 0.0
 
-    for code in codes:
-        norm_code = _normalize_code(code)
-        q = qmap.get(norm_code, {})
-        price = float(q.get("最新价") or q.get("price") or 0)
-        prev_close = float(q.get("昨收") or q.get("prev_close") or 0)
-        change_pct = ((price - prev_close) / prev_close * 100) if prev_close else 0.0
-
-        result[code] = {
-            "price": price,
-            "change_pct": round(change_pct, 2),
-            "volume": float(q.get("成交量") or q.get("volume") or 0),
-            "amount": float(q.get("成交额") or q.get("amount") or 0),
-            "name": q.get("名称") or q.get("name") or code,
-            "industry": None,
-            "pe": None,
-            "pb": None,
-        }
+            result[code] = {
+                "price": price,
+                "change_pct": round(change_pct, 2),
+                "volume": float(q.get("成交量") or q.get("volume") or 0),
+                "amount": float(q.get("成交额") or q.get("amount") or 0),
+                "name": q.get("名称") or q.get("name") or code,
+                "industry": None,
+                "pe": None,
+                "pb": None,
+            }
 
     if (need_industry_name or need_pe_pb) and codes:
         def fetch_one(code: str) -> tuple[str, str | None, float | None, float | None]:
@@ -250,19 +265,8 @@ def screen_stocks_stream(
             candidates,
             need_industry_name=need_industry_name,
             need_pe_pb=need_pe_pb,
+            quote_seed=seed,
         )
-        for code in candidates:
-            nc = _normalize_code(code)
-            if nc in seed:
-                s = seed[nc]
-                q = quote_map.get(code, {})
-                if not q.get("price"):
-                    q["price"] = s["price"]
-                if not q.get("change_pct") and s.get("change_pct") is not None:
-                    q["change_pct"] = s["change_pct"]
-                if not q.get("name"):
-                    q["name"] = s["name"]
-                quote_map[code] = q
     else:
         quote_map = _quote_map_from_seed(candidates, seed)
     t2 = time.time()

--- a/frontend/src/api/stock.ts
+++ b/frontend/src/api/stock.ts
@@ -510,7 +510,7 @@ export const stockApi = {
 
   chanlunMultiLevel(
     code: string,
-    levels = 'daily,weekly,30min',
+    levels = 'weekly,30min',
     options?: GetCacheOptions,
   ) {
     const key = `GET:/chanlun/${code}/multi-level?levels=${levels}`

--- a/frontend/src/composables/index.ts
+++ b/frontend/src/composables/index.ts
@@ -51,6 +51,10 @@ export {
   prefetchStockChanlun,
   prefetchMultiLevelChanlun,
   prefetchStockRouteChunks,
+  prefetchSectorRouteChunks,
+  prefetchSectorStocks,
+  chanlunPrefetchKey,
+  multiLevelPrefetchKey,
   stockLinkPrefetchHandlers,
   sectorLinkPrefetchHandlers,
 } from '../utils/prefetchStock'

--- a/frontend/src/composables/index.ts
+++ b/frontend/src/composables/index.ts
@@ -50,11 +50,13 @@ export {
   onSectorLinkTouch,
   prefetchStockChanlun,
   prefetchMultiLevelChanlun,
+  prefetchStockQuotes,
   prefetchStockRouteChunks,
   prefetchSectorRouteChunks,
   prefetchSectorStocks,
   chanlunPrefetchKey,
   multiLevelPrefetchKey,
+  MULTI_LEVEL_TREND_LEVELS,
   stockLinkPrefetchHandlers,
   sectorLinkPrefetchHandlers,
 } from '../utils/prefetchStock'

--- a/frontend/src/composables/useMultiLevelTrends.ts
+++ b/frontend/src/composables/useMultiLevelTrends.ts
@@ -3,6 +3,8 @@
  */
 import { ref, watch, type MaybeRefOrGetter, toValue } from 'vue'
 import { stockApi } from '@/api/stock'
+import { peekApiCache } from '@/utils/apiCache'
+import { multiLevelPrefetchKey } from '@/utils/prefetchStock'
 
 export type LevelTrendChip = {
   level: string
@@ -61,12 +63,27 @@ export function useMultiLevelTrends(
       return
     }
 
-    loading.value = true
+    const cacheKey = multiLevelPrefetchKey(code, levels)
+    let hadCache = false
+
+    if (!force) {
+      const peek = peekApiCache<Awaited<ReturnType<typeof stockApi.chanlunMultiLevel>>>(cacheKey)
+      if (peek) {
+        levelTrends.value = parseLevels(peek.data.data.levels ?? {})
+        hadCache = true
+        if (!peek.isStale) {
+          loading.value = false
+          return
+        }
+      }
+    }
+
+    loading.value = !hadCache
     try {
       const res = await stockApi.chanlunMultiLevel(code, levels, { force })
       levelTrends.value = parseLevels(res.data.levels ?? {})
     } catch {
-      levelTrends.value = []
+      if (!hadCache) levelTrends.value = []
     } finally {
       loading.value = false
     }

--- a/frontend/src/composables/useMultiLevelTrends.ts
+++ b/frontend/src/composables/useMultiLevelTrends.ts
@@ -1,10 +1,10 @@
 /**
- * 多级别缠论趋势摘要（daily / weekly / 30min），供策略卡片展示。
+ * 多级别缠论趋势摘要（weekly / 30min + 日线合并），供策略卡片展示。
  */
 import { ref, watch, type MaybeRefOrGetter, toValue } from 'vue'
 import { stockApi } from '@/api/stock'
 import { peekApiCache } from '@/utils/apiCache'
-import { multiLevelPrefetchKey } from '@/utils/prefetchStock'
+import { MULTI_LEVEL_TREND_LEVELS, multiLevelPrefetchKey } from '@/utils/prefetchStock'
 
 export type LevelTrendChip = {
   level: string
@@ -24,8 +24,20 @@ const LEVEL_LABELS: Record<string, string> = {
   '1min': '1分',
 }
 
+const LEVEL_ORDER = ['daily', 'weekly', '30min', '60min', '15min', '5min', '1min', 'monthly']
+
+type DailySource = { trend?: string; signals?: unknown[] } | null | undefined
+
+function sortChips(chips: LevelTrendChip[]) {
+  chips.sort((a, b) => {
+    const ia = LEVEL_ORDER.indexOf(a.level)
+    const ib = LEVEL_ORDER.indexOf(b.level)
+    return (ia < 0 ? 99 : ia) - (ib < 0 ? 99 : ib)
+  })
+  return chips
+}
+
 function parseLevels(raw: Record<string, unknown>): LevelTrendChip[] {
-  const order = ['daily', 'weekly', '30min', '60min', '15min', '5min', '1min', 'monthly']
   const chips: LevelTrendChip[] = []
 
   for (const [level, value] of Object.entries(raw)) {
@@ -41,20 +53,32 @@ function parseLevels(raw: Record<string, unknown>): LevelTrendChip[] {
     })
   }
 
-  chips.sort((a, b) => {
-    const ia = order.indexOf(a.level)
-    const ib = order.indexOf(b.level)
-    return (ia < 0 ? 99 : ia) - (ib < 0 ? 99 : ib)
-  })
-  return chips
+  return sortChips(chips)
+}
+
+function mergeDailyChip(chips: LevelTrendChip[], daily: DailySource): LevelTrendChip[] {
+  const trend = String(daily?.trend ?? '').trim()
+  if (!trend || trend === '数据不足') return chips
+  const dailyChip: LevelTrendChip = {
+    level: 'daily',
+    label: LEVEL_LABELS.daily,
+    trend,
+    signalsCount: Array.isArray(daily?.signals) ? daily.signals.length : 0,
+  }
+  return sortChips([dailyChip, ...chips.filter(c => c.level !== 'daily')])
 }
 
 export function useMultiLevelTrends(
   stockCode: MaybeRefOrGetter<string>,
-  levels = 'daily,weekly,30min',
+  levels = MULTI_LEVEL_TREND_LEVELS,
+  dailySource?: MaybeRefOrGetter<DailySource>,
 ) {
   const levelTrends = ref<LevelTrendChip[]>([])
   const loading = ref(false)
+
+  function applyTrends(raw: Record<string, unknown>) {
+    levelTrends.value = mergeDailyChip(parseLevels(raw), toValue(dailySource))
+  }
 
   async function fetchTrends(force = false) {
     const code = toValue(stockCode).trim()
@@ -69,7 +93,7 @@ export function useMultiLevelTrends(
     if (!force) {
       const peek = peekApiCache<Awaited<ReturnType<typeof stockApi.chanlunMultiLevel>>>(cacheKey)
       if (peek) {
-        levelTrends.value = parseLevels(peek.data.data.levels ?? {})
+        applyTrends(peek.data.data.levels ?? {})
         hadCache = true
         if (!peek.isStale) {
           loading.value = false
@@ -81,9 +105,9 @@ export function useMultiLevelTrends(
     loading.value = !hadCache
     try {
       const res = await stockApi.chanlunMultiLevel(code, levels, { force })
-      levelTrends.value = parseLevels(res.data.levels ?? {})
+      applyTrends(res.data.levels ?? {})
     } catch {
-      if (!hadCache) levelTrends.value = []
+      if (!hadCache) levelTrends.value = mergeDailyChip([], toValue(dailySource))
     } finally {
       loading.value = false
     }
@@ -96,6 +120,16 @@ export function useMultiLevelTrends(
     },
     { immediate: true },
   )
+
+  if (dailySource) {
+    watch(
+      () => toValue(dailySource),
+      () => {
+        levelTrends.value = mergeDailyChip(levelTrends.value, toValue(dailySource))
+      },
+      { deep: true },
+    )
+  }
 
   return { levelTrends, loading, refreshTrends: () => fetchTrends(true) }
 }

--- a/frontend/src/composables/useStockPage.ts
+++ b/frontend/src/composables/useStockPage.ts
@@ -6,7 +6,6 @@ import { stockApi, type Quote, type StockInfoFields, type StockExtras } from '..
 import { useChanlunStore, type LevelOption } from '../stores/chanlun'
 import { useCommentStore } from '../stores/comment'
 import { peekApiCache } from '../utils/apiCache'
-import { prefetchMultiLevelChanlun } from '../utils/prefetchStock'
 
 export function useStockPage() {
   const store = useChanlunStore()
@@ -45,7 +44,6 @@ export function useStockPage() {
   ) {
     if (!code) return
     const force = options?.force ?? false
-    void prefetchMultiLevelChanlun(code)
     const tasks: Promise<unknown>[] = [
       store.loadAll(code, level, startDate, endDate, { force }),
       loadQuoteExtras(code, force),

--- a/frontend/src/mobile/components/MobileSearchBar.vue
+++ b/frontend/src/mobile/components/MobileSearchBar.vue
@@ -43,20 +43,45 @@
     </div>
 
     <!-- 搜索结果下拉 -->
-    <div v-if="results.length > 0" class="search-results">
-      <button
-        v-for="s in results"
-        :key="s.code"
-        class="search-result-item"
-        v-bind="stockLinkPrefetchHandlers(s.code)"
-        @click="select(s.code)"
-      >
-        <span class="sri-code mono">{{ s.code }}</span>
-        <span class="sri-name">{{ s.name }}</span>
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="m9 18 6-6-6-6"/>
-        </svg>
-      </button>
+    <div
+      v-if="results.length > 0"
+      class="search-results"
+      :class="{ 'search-vscroll': enableSearchVirtual }"
+      v-bind="enableSearchVirtual ? searchContainerProps : {}"
+    >
+      <div v-if="enableSearchVirtual" class="search-vscroll-spacer" v-bind="searchWrapperProps">
+        <div class="search-vscroll-inner" :style="{ transform: `translateY(${searchOffsetY}px)` }">
+          <button
+            v-for="s in searchDisplay"
+            :key="s.code"
+            class="search-result-item"
+            :style="{ height: SEARCH_ROW_H + 'px' }"
+            v-bind="stockLinkPrefetchHandlers(s.code)"
+            @click="select(s.code)"
+          >
+            <span class="sri-code mono">{{ s.code }}</span>
+            <span class="sri-name">{{ s.name }}</span>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="m9 18 6-6-6-6"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+      <template v-else>
+        <button
+          v-for="s in searchDisplay"
+          :key="s.code"
+          class="search-result-item"
+          v-bind="stockLinkPrefetchHandlers(s.code)"
+          @click="select(s.code)"
+        >
+          <span class="sri-code mono">{{ s.code }}</span>
+          <span class="sri-name">{{ s.name }}</span>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="m9 18 6-6-6-6"/>
+          </svg>
+        </button>
+      </template>
     </div>
     <!-- 搜索中 -->
     <div v-if="searching" class="search-loading">
@@ -73,9 +98,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted } from 'vue'
+import { ref, watch, computed, onMounted, onUnmounted } from 'vue'
 import { useDebouncedStockSearch } from '@/composables/useDebouncedStockSearch'
-import { prefetchStockChanlun, stockLinkPrefetchHandlers } from '@/utils/prefetchStock'
+import { useVirtualScroll } from '@/composables/useVirtualScroll'
+import { onStockLinkTouch, stockLinkPrefetchHandlers } from '@/utils/prefetchStock'
 
 const emit = defineEmits<{ search: [code: string] }>()
 
@@ -93,6 +119,23 @@ const {
   searchImmediate,
   clear: clearSearch,
 } = useDebouncedStockSearch(300)
+
+const SEARCH_ROW_H = 44
+const enableSearchVirtual = computed(() => results.value.length > 20)
+const {
+  visibleItems: searchVisible,
+  containerProps: searchContainerProps,
+  wrapperProps: searchWrapperProps,
+  offsetY: searchOffsetY,
+} = useVirtualScroll({
+  items: results,
+  itemHeight: SEARCH_ROW_H,
+  overscan: 3,
+  maxHeight: 280,
+})
+const searchDisplay = computed(() =>
+  enableSearchVirtual.value ? searchVisible.value : results.value,
+)
 
 function focus() {
   const input = document.querySelector('.search-input') as HTMLInputElement
@@ -131,7 +174,7 @@ async function doSearch() {
 }
 
 function select(code: string) {
-  prefetchStockChanlun(code)
+  onStockLinkTouch(code)
   saveHistory(code)
   results.value = []
   keyword.value = ''
@@ -280,14 +323,21 @@ onUnmounted(() => {
   top: 100%;
   left: 0;
   right: 0;
+  max-height: 280px;
+  overflow-y: auto;
   background: var(--bg-card);
   border: 1px solid var(--border-strong);
   border-top: none;
   border-radius: 0 0 12px 12px;
-  overflow: hidden;
   box-shadow: var(--shadow-md);
   z-index: 99;
+  scrollbar-width: thin;
 }
+.search-results.search-vscroll {
+  overflow-y: auto;
+}
+.search-vscroll-spacer { position: relative; width: 100%; }
+.search-vscroll-inner { width: 100%; }
 
 .search-result-item {
   display: flex;

--- a/frontend/src/mobile/components/MobileSearchBar.vue
+++ b/frontend/src/mobile/components/MobileSearchBar.vue
@@ -48,6 +48,7 @@
         v-for="s in results"
         :key="s.code"
         class="search-result-item"
+        v-bind="stockLinkPrefetchHandlers(s.code)"
         @click="select(s.code)"
       >
         <span class="sri-code mono">{{ s.code }}</span>
@@ -74,6 +75,7 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, onUnmounted } from 'vue'
 import { useDebouncedStockSearch } from '@/composables/useDebouncedStockSearch'
+import { prefetchStockChanlun, stockLinkPrefetchHandlers } from '@/utils/prefetchStock'
 
 const emit = defineEmits<{ search: [code: string] }>()
 
@@ -129,6 +131,7 @@ async function doSearch() {
 }
 
 function select(code: string) {
+  prefetchStockChanlun(code)
   saveHistory(code)
   results.value = []
   keyword.value = ''

--- a/frontend/src/mobile/components/MobileStockSheet.vue
+++ b/frontend/src/mobile/components/MobileStockSheet.vue
@@ -131,7 +131,7 @@ import { ref, computed, defineAsyncComponent } from 'vue'
 import type { Quote, StockInfoFields, Signal, AISignal } from '@/api/stock'
 import { useCommentStore } from '@/stores/comment'
 import { useVolumeFormatter } from '@/composables/useFormatters'
-import { useMultiLevelTrends } from '@/composables/useMultiLevelTrends'
+import type { LevelTrendChip } from '@/composables/useMultiLevelTrends'
 import MultiLevelTrendChips from '@/components/Signal/MultiLevelTrendChips.vue'
 
 const MobileCommentSection = defineAsyncComponent(
@@ -150,9 +150,8 @@ const props = defineProps<{
     signals: Signal[]
   } | null
   aiSignal: AISignal | null
+  levelTrends: LevelTrendChip[]
 }>()
-
-const { levelTrends } = useMultiLevelTrends(() => props.stockCode)
 
 defineEmits<{
   'update:modelValue': [val: boolean]

--- a/frontend/src/mobile/views/MobileHomeView.vue
+++ b/frontend/src/mobile/views/MobileHomeView.vue
@@ -18,6 +18,7 @@
             class="idx-card"
             :class="ix.change_pct >= 0 ? 'card-up' : 'card-down'"
             @click="go(`/m/stock/${ix.code}`)"
+            v-bind="stockLinkPrefetchHandlers(ix.code)"
           >
             <div class="idx-top">
               <span class="idx-name">{{ ix.name }}</span>

--- a/frontend/src/mobile/views/MobileScreenView.vue
+++ b/frontend/src/mobile/views/MobileScreenView.vue
@@ -302,6 +302,7 @@ function resetFilters() {
   filters.pb_max = undefined
   filters.signals = ''
   results.value = []
+  persistScreenFilters()
 }
 
 async function doScreen() {

--- a/frontend/src/mobile/views/MobileStockView.vue
+++ b/frontend/src/mobile/views/MobileStockView.vue
@@ -53,6 +53,12 @@
         <button class="btn btn-ghost btn-sm" @click="showSheet = true">详情</button>
       </div>
 
+      <MultiLevelTrendChips
+        v-if="levelTrends.length"
+        :trends="levelTrends"
+        class="mobile-level-trends"
+      />
+
       <div v-if="store.chanlunResult?.signals?.length" class="signals-preview">
         <div class="sp-head">
           <span class="sp-title">缠论信号</span>
@@ -126,8 +132,10 @@ import { useWatchlistStore } from '@/stores/watchlist'
 import type { Quote } from '@/api/stock'
 import toast from '@/composables/useToast'
 import { useStockPage } from '@/composables/useStockPage'
+import { useMultiLevelTrends } from '@/composables/useMultiLevelTrends'
 import { useVisibilityRefresh } from '@/composables/useVisibilityRefresh'
 import { API_CACHE_TTL } from '@/utils/apiCache'
+import MultiLevelTrendChips from '@/components/Signal/MultiLevelTrendChips.vue'
 import MobileKLineChart from '../components/MobileKLineChart.vue'
 import MobileIndicatorSelector from '../components/MobileIndicatorSelector.vue'
 
@@ -159,6 +167,7 @@ const onZoomChange = useDebouncedCallback((s: number, e: number) => {
 }, 80)
 
 const stockCode = computed(() => route.params.code as string)
+const { levelTrends } = useMultiLevelTrends(stockCode)
 const currentLevel = computed(() => store.currentLevel)
 const loadingAny = computed(() => store.loadingKline || store.loadingChanlun)
 const showInitialLoading = computed(
@@ -315,8 +324,10 @@ watch(() => route.params.code, () => { signalsExpanded.value = false; loadData()
 
 .chart-controls {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
+  margin-bottom: 8px;
 }
 
 .level-tabs {
@@ -353,6 +364,11 @@ watch(() => route.params.code, () => { signalsExpanded.value = false; loadData()
   padding: 8px 12px;
   min-height: 36px;
   font-size: 0.8rem;
+}
+
+.mobile-level-trends {
+  margin-bottom: 10px;
+  padding: 0 2px;
 }
 
 .signals-preview {

--- a/frontend/src/mobile/views/MobileStockView.vue
+++ b/frontend/src/mobile/views/MobileStockView.vue
@@ -119,6 +119,7 @@
       :chanlun-result="store.chanlunResult"
       :ai-signal="store.aiSignal"
       :loading-a-i="store.loadingAI"
+      :level-trends="levelTrends"
     />
   </div>
 </template>
@@ -133,6 +134,7 @@ import type { Quote } from '@/api/stock'
 import toast from '@/composables/useToast'
 import { useStockPage } from '@/composables/useStockPage'
 import { useMultiLevelTrends } from '@/composables/useMultiLevelTrends'
+import { MULTI_LEVEL_TREND_LEVELS } from '@/utils/prefetchStock'
 import { useVisibilityRefresh } from '@/composables/useVisibilityRefresh'
 import { API_CACHE_TTL } from '@/utils/apiCache'
 import MultiLevelTrendChips from '@/components/Signal/MultiLevelTrendChips.vue'
@@ -147,11 +149,27 @@ const route = useRoute()
 const { store, quote, stockInfo, loadStock, changeLevel: changeLevelBase, refreshAIStrategy, refreshQuotes } = useStockPage()
 const watchlistStore = useWatchlistStore()
 
+const CHART_ZOOM_KEY = 'chanstock_m_chart_zoom_v1'
+
 const zoomStart = ref(0)
 const zoomEnd = ref(100)
 const showSheet = ref(false)
 const sheetMounted = ref(false)
 const signalsExpanded = ref(false)
+
+function restoreChartZoom() {
+  try {
+    const raw = localStorage.getItem(CHART_ZOOM_KEY)
+    if (!raw) return
+    const parsed = JSON.parse(raw) as { start?: number; end?: number }
+    if (typeof parsed.start === 'number' && typeof parsed.end === 'number') {
+      zoomStart.value = parsed.start
+      zoomEnd.value = parsed.end
+    }
+  } catch {
+    /* ignore */
+  }
+}
 
 watch(showSheet, (open) => {
   if (open) sheetMounted.value = true
@@ -164,10 +182,19 @@ const isWatching = computed(() =>
 const onZoomChange = useDebouncedCallback((s: number, e: number) => {
   zoomStart.value = s
   zoomEnd.value = e
+  try {
+    localStorage.setItem(CHART_ZOOM_KEY, JSON.stringify({ start: s, end: e }))
+  } catch {
+    /* ignore */
+  }
 }, 80)
 
 const stockCode = computed(() => route.params.code as string)
-const { levelTrends } = useMultiLevelTrends(stockCode)
+const { levelTrends } = useMultiLevelTrends(
+  stockCode,
+  MULTI_LEVEL_TREND_LEVELS,
+  () => store.chanlunResult,
+)
 const currentLevel = computed(() => store.currentLevel)
 const loadingAny = computed(() => store.loadingKline || store.loadingChanlun)
 const showInitialLoading = computed(
@@ -268,6 +295,7 @@ async function toggleWatch() {
 }
 
 onMounted(() => {
+  restoreChartZoom()
   void watchlistStore.fetchWatchlist()
   loadData()
 })

--- a/frontend/src/mobile/views/MobileWatchlistView.vue
+++ b/frontend/src/mobile/views/MobileWatchlistView.vue
@@ -51,7 +51,6 @@
             class="stock-row"
             :style="{ height: ROW_H + 'px' }"
             @click="go(`/m/stock/${s.code}`)"
-            @click="go(`/m/stock/${s.code}`)"
             v-bind="stockLinkPrefetchHandlers(s.code)"
           >
             <div class="sr-left">

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,6 +1,11 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import { peekApiCache } from '../utils/apiCache'
 import {
+  chanlunPrefetchKey,
+  multiLevelPrefetchKey,
   prefetchMultiLevelChanlun,
+  prefetchSectorRouteChunks,
+  prefetchSectorStocks,
   prefetchStockChanlun,
   prefetchStockRouteChunks,
 } from '../utils/prefetchStock'
@@ -37,12 +42,20 @@ const router = createRouter({
 
 router.beforeEach(to => {
   const code = typeof to.params.code === 'string' ? to.params.code : ''
-  if (!/^\d{6}$/.test(code)) return true
-  if (to.path.startsWith('/stock/') || to.path.startsWith('/m/stock/')) {
+  if (/^\d{6}$/.test(code) && (to.path.startsWith('/stock/') || to.path.startsWith('/m/stock/'))) {
     prefetchStockRouteChunks()
-    prefetchStockChanlun(code)
-    prefetchMultiLevelChanlun(code)
+    const dailyKey = chanlunPrefetchKey(code)
+    if (!peekApiCache(dailyKey)) prefetchStockChanlun(code)
+    const multiKey = multiLevelPrefetchKey(code)
+    if (!peekApiCache(multiKey)) prefetchMultiLevelChanlun(code)
   }
+
+  const name = typeof to.params.name === 'string' ? decodeURIComponent(to.params.name) : ''
+  if (name && (to.path.startsWith('/sector/') || to.path.startsWith('/m/sector/'))) {
+    prefetchSectorRouteChunks()
+    prefetchSectorStocks(name)
+  }
+
   return true
 })
 

--- a/frontend/src/stores/chanlun.ts
+++ b/frontend/src/stores/chanlun.ts
@@ -169,6 +169,15 @@ export const useChanlunStore = defineStore('chanlun', () => {
         klineUpdatedAt.value = timeNow()
         errorKline.value = null
         if (!peek.isStale) return
+        void stockApi
+          .kline(code, level, 500, startDate, endDate, { force: true })
+          .then(res => {
+            if (seq != null && isStale(seq)) return
+            klines.value = res.data.klines || []
+            klineUpdatedAt.value = timeNow()
+          })
+          .catch(() => { /* 保留 stale */ })
+        return
       }
     }
 
@@ -202,6 +211,14 @@ export const useChanlunStore = defineStore('chanlun', () => {
         if (seq != null && isStale(seq)) return
         applyChanlunPayload(peek.data.data)
         if (!peek.isStale) return
+        void stockApi
+          .chanlun(code, level, { force: true })
+          .then(res => {
+            if (seq != null && isStale(seq)) return
+            applyChanlunPayload(res.data)
+          })
+          .catch(() => { /* 保留 stale */ })
+        return
       }
     }
 

--- a/frontend/src/utils/prefetchStock.ts
+++ b/frontend/src/utils/prefetchStock.ts
@@ -29,6 +29,10 @@ export function chanlunPrefetchKey(code: string, level = 'daily') {
   return `GET:/chanlun/${code}?level=${level}`
 }
 
+export function multiLevelPrefetchKey(code: string, levels = 'daily,weekly,30min') {
+  return `GET:/chanlun/${code.trim()}/multi-level?levels=${levels}`
+}
+
 function isStockCode(code: string) {
   return /^\d{6}$/.test(code.trim())
 }
@@ -55,7 +59,7 @@ export function prefetchMultiLevelChanlun(code: string, levels = 'daily,weekly,3
   const trimmed = code.trim()
   if (!isStockCode(trimmed)) return
 
-  const key = `GET:/chanlun/${trimmed}/multi-level?levels=${levels}`
+  const key = multiLevelPrefetchKey(trimmed, levels)
   if (peekApiCache(key) || inflightMulti.has(key)) return
 
   inflightMulti.add(key)
@@ -83,11 +87,13 @@ export function prefetchSectorStocks(name: string) {
 
 export function onStockLinkHover(code: string, level = 'daily') {
   prefetchStockChanlun(code, level)
+  prefetchMultiLevelChanlun(code)
 }
 
 /** 移动端无 hover，touchstart 时触发同等预取 */
 export function onStockLinkTouch(code: string, level = 'daily') {
   prefetchStockChanlun(code, level)
+  prefetchMultiLevelChanlun(code)
 }
 
 export function onSectorLinkHover(name: string) {

--- a/frontend/src/utils/prefetchStock.ts
+++ b/frontend/src/utils/prefetchStock.ts
@@ -4,11 +4,15 @@
 import { peekApiCache } from './apiCache'
 import { stockApi } from '../api/stock'
 
+/** 多级别趋势默认只拉周线+30分，日线由 loadAll 的缠论结果合并 */
+export const MULTI_LEVEL_TREND_LEVELS = 'weekly,30min'
+
 let routeChunksPrefetched = false
 let sectorChunksPrefetched = false
 const inflightChanlun = new Set<string>()
 const inflightMulti = new Set<string>()
 const inflightSector = new Set<string>()
+const inflightQuotes = new Set<string>()
 
 export function prefetchStockRouteChunks() {
   if (routeChunksPrefetched) return
@@ -29,7 +33,7 @@ export function chanlunPrefetchKey(code: string, level = 'daily') {
   return `GET:/chanlun/${code}?level=${level}`
 }
 
-export function multiLevelPrefetchKey(code: string, levels = 'daily,weekly,30min') {
+export function multiLevelPrefetchKey(code: string, levels = MULTI_LEVEL_TREND_LEVELS) {
   return `GET:/chanlun/${code.trim()}/multi-level?levels=${levels}`
 }
 
@@ -54,8 +58,8 @@ export function prefetchStockChanlun(code: string, level = 'daily') {
     .finally(() => inflightChanlun.delete(key))
 }
 
-/** 预取多级别缠论（daily+weekly+30min），供策略卡片与共振计算 */
-export function prefetchMultiLevelChanlun(code: string, levels = 'daily,weekly,30min') {
+/** 预取多级别缠论（weekly+30min），供策略卡片与共振计算 */
+export function prefetchMultiLevelChanlun(code: string, levels = MULTI_LEVEL_TREND_LEVELS) {
   const trimmed = code.trim()
   if (!isStockCode(trimmed)) return
 
@@ -85,15 +89,37 @@ export function prefetchSectorStocks(name: string) {
     .finally(() => inflightSector.delete(key))
 }
 
+/** 预取行情/基本面/扩展信息，缩短个股页头部展示 */
+export function prefetchStockQuotes(code: string) {
+  const trimmed = code.trim()
+  if (!isStockCode(trimmed) || inflightQuotes.has(trimmed)) return
+
+  const quoteKey = `GET:/stocks/${trimmed}/quote`
+  const infoKey = `GET:/stocks/${trimmed}/info`
+  const extrasKey = `GET:/stocks/${trimmed}/extras:8`
+  if (peekApiCache(quoteKey) && peekApiCache(infoKey) && peekApiCache(extrasKey)) return
+
+  inflightQuotes.add(trimmed)
+  void Promise.allSettled([
+    stockApi.quote(trimmed),
+    stockApi.info(trimmed),
+    stockApi.extras(trimmed, 8),
+  ])
+    .catch(() => { /* 预取失败静默 */ })
+    .finally(() => inflightQuotes.delete(trimmed))
+}
+
 export function onStockLinkHover(code: string, level = 'daily') {
   prefetchStockChanlun(code, level)
   prefetchMultiLevelChanlun(code)
+  prefetchStockQuotes(code)
 }
 
 /** 移动端无 hover，touchstart 时触发同等预取 */
 export function onStockLinkTouch(code: string, level = 'daily') {
   prefetchStockChanlun(code, level)
   prefetchMultiLevelChanlun(code)
+  prefetchStockQuotes(code)
 }
 
 export function onSectorLinkHover(name: string) {

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -35,6 +35,7 @@
                 v-for="item in liveResults"
                 :key="item.code"
                 class="live-item"
+                v-bind="stockLinkPrefetchHandlers(item.code)"
                 @mousedown.prevent="keyword = item.code; search()"
               >
                 <span class="live-name">{{ item.name }}</span>

--- a/frontend/src/views/StockScreenView.vue
+++ b/frontend/src/views/StockScreenView.vue
@@ -106,9 +106,14 @@
           <button v-if="loading" type="button" class="btn btn-ghost run-btn stop-screen-btn" @click="stopScreen">
             停止筛选
           </button>
-          <button v-else type="button" class="btn btn-primary run-btn" @click="runScreen">
-            开始选股
-          </button>
+          <template v-else>
+            <div class="run-actions">
+              <button type="button" class="btn btn-ghost run-btn" @click="resetFilters">重置条件</button>
+              <button type="button" class="btn btn-primary run-btn" @click="runScreen">
+                开始选股
+              </button>
+            </div>
+          </template>
 
           <p v-if="loading" class="loading-hint">
             正在分析股票，请稍候…
@@ -384,6 +389,22 @@ function clearResults() {
   resetScreen()
 }
 
+function resetFilters() {
+  params.change_pct_min = null
+  params.change_pct_max = null
+  params.volume_min = null
+  params.volume_max = null
+  params.industry = ''
+  params.pe_max = null
+  params.pb_max = null
+  params.dual_cross = false
+  params.level = 'daily'
+  params.pool_size = 100
+  selectedSignals.value = []
+  clearResults()
+  persistScreenFilters()
+}
+
 function exportResults() {
   downloadScreenResultsCsv(sortedResults.value)
 }
@@ -556,6 +577,13 @@ function trendClass(trend: string): string {
   cursor: pointer;
   transition: opacity 0.15s;
 }
+.run-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 18px;
+}
+.run-actions .run-btn { margin-top: 0; }
 .run-btn:disabled { opacity: 0.6; cursor: not-allowed; }
 
 .loading-hint { font-size: 0.75rem; color: var(--text-muted); text-align: center; margin-top: 8px; }

--- a/frontend/src/views/StockView.vue
+++ b/frontend/src/views/StockView.vue
@@ -336,6 +336,7 @@ import toast from '../composables/useToast'
 import { resolveApiBaseURL } from '../api/stock'
 import { useStockPage } from '../composables/useStockPage'
 import { useMultiLevelTrends } from '../composables/useMultiLevelTrends'
+import { MULTI_LEVEL_TREND_LEVELS } from '../utils/prefetchStock'
 import { useVisibilityRefresh } from '../composables/useVisibilityRefresh'
 import { API_CACHE_TTL } from '../utils/apiCache'
 const KLineChart = defineAsyncComponent(
@@ -364,7 +365,7 @@ const isWatching = computed(() =>
 )
 
 const stockCode = computed(() => route.params.code as string)
-const { levelTrends } = useMultiLevelTrends(stockCode)
+const { levelTrends } = useMultiLevelTrends(stockCode, MULTI_LEVEL_TREND_LEVELS, () => store.chanlunResult)
 const currentLevel = computed(() => store.currentLevel)
 const loadingAny = computed(() =>
   store.loadingKline || store.loadingChanlun


### PR DESCRIPTION
## Summary
- 后端：市场/板块/新闻缓存分层，选股流式优化（热门池成交量修复、行业/PE 懒加载、双金叉一次计算、早停取消），统一 MACD+SKDJ 双金叉逻辑并补充测试
- 前端：API LRU 缓存与 stale-while-revalidate，首页/板块/自选股可见性刷新；选股 SSE 重试/停止/去重、条件持久化、排序与 CSV 导出；K 线单实例 + dataZoom 保留 + 增量 overlay 更新；行情/缠论预取补全、多级别趋势去重；移动端搜索虚拟滚动与图表缩放记忆
- 工程：README 截图画廊与截图脚本，移除 SkeletonLoader/独立副图组件，清理 verify_cross 与本地 json 配置

## Test plan
- [ ] 首页/板块/自选股：切换标签页后 stale 数据能后台刷新
- [ ] 选股页：流式结果实时展示，停止后保留部分结果，重置条件/持久化/重试与 CSV 导出正常
- [ ] 个股页：切换周期/指标时 dataZoom 不重置，缠论 overlay 切换流畅，列表 hover 预取后进入更快
- [ ] 移动端：搜索下拉与自选股虚拟滚动流畅，图表缩放记忆生效
- [ ] AI 诊股：流式输出时可停止，切换股票后对话重置
- [ ] 后端 pytest 与前端 vitest 通过